### PR TITLE
Add Commerce Connect

### DIFF
--- a/data/Products/Sitecore Commerce Connect.json
+++ b/data/Products/Sitecore Commerce Connect.json
@@ -1,0 +1,6 @@
+{
+  "Metadata": {
+    "Alias": "COMCON",
+    "DefaultPackage": "COMCON.Sitecore.Commerce",
+  }
+}

--- a/data/Products/Sitecore Commerce Connect/8.0/150105.json
+++ b/data/Products/Sitecore Commerce Connect/8.0/150105.json
@@ -1,0 +1,13 @@
+{
+  "Label": "Initial Release",
+  "Date": "2015-01-05",
+  "Update": "0",
+  "Distributions": {
+    "default": {
+      "Downloads": {
+        "Link": "https://dev.sitecore.net/~/media/D5492A8AB3F64947AE1F1D8249E0013E.ashx",
+        "Path": "Sitecore Commerce Connect 8.0 rev. 150105.zip/package.zip",
+      },
+    },
+  }
+}

--- a/data/Products/Sitecore Commerce Connect/8.1/160202.json
+++ b/data/Products/Sitecore Commerce Connect/8.1/160202.json
@@ -1,0 +1,13 @@
+{
+  "Label": "Initial Release",
+  "Date": "2016-02-02",
+  "Update": "0",
+  "Distributions": {
+    "default": {
+      "Downloads": {
+        "Link": "https://dev.sitecore.net/~/media/B4DF3ABFB30F4282AC487E8FF8B8FE90.ashx",
+        "Path": "Sitecore Commerce Connect 8.1 rev. 160202.zip/package.zip",
+      },
+    },
+  }
+}


### PR DESCRIPTION
This pull request is required after rolling-back Commerce-related changes that broke SIS. In order to prevent further SIS corruption, it was decided to split master branch which is being processed by Build Server that converts it into http://dl.sitecore.net/updater/info metabase. The develop branch contains current WIP (work-in-progress) which is safe to change. Changes in develop branch are dispatched to master using pull requests like this. The pull request can be created by anybody, but it can be approved by administrators.

Some details of rolling-back Commerce-related changes that broke SIS. There were issues:
* Missing `Sitecore Commerce powered by Commerce Server.json` file
* Missing `Sitecore Commerce Connect.json` file (there were two incompatible `Sitecore Commerce Connect 8.1.json` and `Sitecore Commerce Connect 8.2.json`)